### PR TITLE
Feat/tests

### DIFF
--- a/src/hiragana.zig
+++ b/src/hiragana.zig
@@ -17,15 +17,13 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
     .{ "ko", "こ" },
 
     .{ "sa", "さ" },
-    .{ "shi", "し" },
+    .{ "si", "し" },
     .{ "su", "す" },
     .{ "se", "せ" },
     .{ "so", "そ" },
 
     .{ "ta", "た" },
-    .{ "chi", "ち" },
     .{ "ti", "ち" },
-    .{ "tsu", "つ" },
     .{ "tu", "つ" },
     .{ "te", "て" },
     .{ "to", "と" },
@@ -62,35 +60,6 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
     .{ "wo", "を" },
     .{ "n", "ん" },
 
-    // Palatalized sounds
-    .{ "kya", "きゃ" },
-    .{ "kyu", "きゅ" },
-    .{ "kyo", "きょ" },
-
-    .{ "sha", "しゃ" },
-    .{ "shu", "しゅ" },
-    .{ "sho", "しょ" },
-
-    .{ "cha", "ちゃ" },
-    .{ "chu", "ちゅ" },
-    .{ "cho", "ちょ" },
-
-    .{ "nya", "にゃ" },
-    .{ "nyu", "にゅ" },
-    .{ "nyo", "にょ" },
-
-    .{ "hya", "ひゃ" },
-    .{ "hyu", "ひゅ" },
-    .{ "hyo", "ひょ" },
-
-    .{ "mya", "みゃ" },
-    .{ "myu", "みゅ" },
-    .{ "myo", "みょ" },
-
-    .{ "rya", "りゃ" },
-    .{ "ryu", "りゅ" },
-    .{ "ryo", "りょ" },
-
     // Voiced consonants
     .{ "ga", "が" },
     .{ "gi", "ぎ" },
@@ -99,7 +68,7 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
     .{ "go", "ご" },
 
     .{ "za", "ざ" },
-    .{ "ji", "じ" },
+    .{ "zi", "じ" },
     .{ "zu", "ず" },
     .{ "ze", "ぜ" },
     .{ "zo", "ぞ" },
@@ -122,7 +91,64 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
     .{ "pe", "ぺ" },
     .{ "po", "ぽ" },
 
-    // WTF
+    // Palatalized sounds
+    .{ "kya", "きゃ" },
+    .{ "kyi", "きぃ"},
+    .{ "kyu", "きゅ" },
+    .{ "kye", "きぇ" },
+    .{ "kyo", "きょ" },
+
+    .{ "nya", "にゃ" },
+    .{ "nyi", "にぃ" },
+    .{ "nyu", "にゅ" },
+    .{ "nye", "にぇ" },
+    .{ "nyo", "にょ" },
+
+    .{ "hya", "ひゃ" },
+    .{ "hyi", "ひぃ" },
+    .{ "hyu", "ひゅ" },
+    .{ "hye", "ひぇ" },
+    .{ "hyo", "ひょ" },
+
+    .{ "mya", "みゃ" },
+    .{ "myi", "みぃ" },
+    .{ "myu", "みゅ" },
+    .{ "mye", "みぇ" },
+    .{ "myo", "みょ" },
+
+    .{ "rya", "りゃ" },
+    .{ "ryi", "りぃ" },
+    .{ "ryu", "りゅ" },
+    .{ "rye", "りぇ" },
+    .{ "ryo", "りょ" },
+
+    .{ "tya", "ちゃ" },
+    .{ "tyi", "ちぃ" },
+    .{ "tyu", "ちゅ" },
+    .{ "tye", "ちぇ" },
+    .{ "tyo", "ちょ" },
+
+    .{ "cya", "ちゃ" },
+    .{ "cyi", "ちぃ" },
+    .{ "cyu", "ちゅ" },
+    .{ "cye", "ちぇ" },
+    .{ "cyo", "ちょ" },
+    
+    .{ "pya", "ぴゃ" },
+    .{ "pyi", "ぴぃ" },
+    .{ "pyu", "ぴゅ" },
+    .{ "pye", "ぴぇ" },
+    .{ "pyo", "ぴょ" },
+    
+    .{ "bya", "びゃ" },
+    .{ "byi", "びぃ" },
+    .{ "byu", "びゅ" },
+    .{ "bye", "びぇ" },
+    .{ "byo", "びょ" },
+
+    // Other
+    .{ "ye", "いぇ" },
+
     .{ "tsa", "つぁ" },
     .{ "tsi", "つぃ" },
     .{ "tsu", "つ" },
@@ -141,28 +167,22 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
     .{ "she", "しぇ" },
     .{ "sho", "しょ" },
 
-    .{ "chya", "ちゃ" },
-    .{ "chyi", "ちぃ" },
-    .{ "chyu", "ちゅ" },
-    .{ "chye", "ちぇ" },
-    .{ "chyo", "ちょ" },
+    .{ "qa", "くぁ" },
+    .{ "qi", "くぃ" },
+    .{ "qu", "く" },
+    .{ "qe", "くぇ" },
+    .{ "qo", "くぉ" },
 
-    .{ "ye", "いぇ" },
-
-    .{ "tya", "ちゃ" },
-    .{ "tyi", "ちぃ" },
-    .{ "tyu", "ちゅ" },
-    .{ "tye", "ちぇ" },
-    .{ "tyo", "ちょ" },
-
-    .{ "cya", "ちゃ" },
-    .{ "cyi", "ちぃ" },
-    .{ "cyu", "ちゅ" },
-    .{ "cye", "ちぇ" },
-    .{ "cyo", "ちょ" },
+    .{ "ja", "じゃ" },
+    .{ "ji", "じ" },
+    .{ "ju", "じゅ" },
+    .{ "je", "じぇ" },
+    .{ "jo", "じょ" },
 });
 
 pub const SmallTransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
+    .{ "tsu", "っ" },
+
     .{ "ke", "ヶ" },
     .{ "ka", "ヵ" },
 

--- a/src/hiragana.zig
+++ b/src/hiragana.zig
@@ -36,7 +36,7 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
 
     .{ "ha", "は" },
     .{ "hi", "ひ" },
-    .{ "fu", "ふ" },
+    .{ "hu", "ふ" },
     .{ "he", "へ" },
     .{ "ho", "ほ" },
 
@@ -148,6 +148,12 @@ pub const TransliterationMap = std.StaticStringMap([]const u8).initComptime(.{
 
     // Other
     .{ "ye", "いぇ" },
+
+    .{ "tha", "てゃ" },
+    .{ "thi", "てぃ" },
+    .{ "thu", "てゅ" },
+    .{ "the", "てぇ" },
+    .{ "tho", "てょ" },
 
     .{ "tsa", "つぁ" },
     .{ "tsi", "つぃ" },

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,7 +10,7 @@ pub fn main() !void {
 
     var fsm = try RomajiParseFsm.init(arena.allocator());
 
-    const input = "xyixyuxyaxkexkalkelkalilalulolgolkiliilxi";
+    const input = "qaqiquqejijajujoyayiyeyochipichipipya";
 
     for (input) |c| {
         const result = try fsm.process(c);

--- a/src/test-data/transliterations.txt
+++ b/src/test-data/transliterations.txt
@@ -1,0 +1,190 @@
+# Group 1: Basic vowels
+a あ
+i い
+u う
+e え
+o お
+
+# Group 2: Consonant + vowel combinations
+ka か
+ki き
+ku く
+ke け
+ko こ
+
+sa さ
+si し
+su す
+se せ
+so そ
+
+ta た
+ti ち
+tu つ
+te て
+to と
+
+na な
+ni に
+nu ぬ
+ne ね
+no の
+
+ha は
+hi ひ
+hu ふ
+he へ
+ho ほ
+
+ma ま
+mi み
+mu む
+me め
+mo も
+
+ya や
+yu ゆ
+yo よ
+
+ra ら
+ri り
+ru る
+re れ
+ro ろ
+
+wa わ
+wo を
+nn ん
+
+# Group 3: Modified consonants (with dakuten or handakuten)
+ga が
+gi ぎ
+gu ぐ
+ge げ
+go ご
+
+za ざ
+zi じ
+zu ず
+ze ぜ
+zo ぞ
+
+da だ
+di ぢ
+du づ
+de で
+do ど
+
+ba ば
+bi び
+bu ぶ
+be べ
+bo ぼ
+
+pa ぱ
+pi ぴ
+pu ぷ
+pe ぺ
+po ぽ
+
+# Group 4: Combinations with 'y' (ya, yu, yo combinations)
+kya きゃ
+kyi きぃ
+kyu きゅ
+kye きぇ
+kyo きょ
+
+nya にゃ
+nyi にぃ
+nyu にゅ
+nye にぇ
+nyo にょ
+
+hya ひゃ
+hyi ひぃ
+hyu ひゅ
+hye ひぇ
+hyo ひょ
+
+mya みゃ
+myi みぃ
+myu みゅ
+mye みぇ
+myo みょ
+
+rya りゃ
+ryi りぃ
+ryu りゅ
+rye りぇ
+ryo りょ
+
+# Group 5: Other consonants
+tha てゃ
+thi てぃ
+thu てゅ
+the てぇ
+tho てょ
+
+tsa つぁ
+tsi つぃ
+tsu つ
+tse つぇ
+tso つぉ
+
+sha しゃ
+shi し
+shu しゅ
+sho しょ
+she しぇ
+
+cha ちゃ
+chi ち
+chu ちゅ
+che ちぇ
+cho ちょ
+
+qa くぁ
+qi くぃ
+qu く
+qe くぇ
+qo くぉ
+
+ja じゃ
+ji じ
+ju じゅ
+je じぇ
+jo じょ
+
+# Group 6: Small kana and special combinations (x-prefixed)
+xtsu っ
+xke ヶ
+xka ヵ
+
+xa ぁ
+xi ぃ
+xu ぅ
+xe ぇ
+xo ぉ
+
+xya ゃ
+xyi ぃ
+xyu ゅ
+xye ぇ
+xyo ょ
+
+# Group 7: Small kana and special combinations (l-prefixed)
+ltsu っ
+lke ヶ
+lka ヵ
+
+la ぁ
+li ぃ
+lu ぅ
+le ぇ
+lo ぉ
+
+lya ゃ
+lyi ぃ
+lyu ゅ
+lye ぇ
+lyo ょ


### PR DESCRIPTION
- Add ThConsonant state to FSM for handling 'th' combinations
- Add comprehensive test framework using transliterations.txt
- Fix 'fu' -> 'hu' mapping in hiragana.zig to match test data
- Add test data file with organized groups of romaji-hiragana pairs
Closes #8 