### PR TITLE
feat: add deleteBack and deleteForward functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ try ime.insert("n");
 try std.testing.expectEqualStrings("こん", ime.input.buf.items());
 
 // Cursor movement and editing
-ime.moveCursorBack();  // Move cursor left
-try ime.insert("y");   // Insert at cursor
-ime.clear();          // Clear the buffer
+ime.moveCursorBack();   // Move cursor left
+try ime.insert("y");    // Insert at cursor
+ime.clear();            // Clear the buffer
+ime.deleteBack();       // Delete the last character
+ime.deleteForward();    // Delete the next character
 ```
 
 ## Features

--- a/src/Utf8Input.zig
+++ b/src/Utf8Input.zig
@@ -193,16 +193,18 @@ pub fn Utf8Input(comptime tag: StorageTag) type {
             return it.peekForward(1);
         }
 
-        pub fn deleteForward(self: *Self, n: usize) !void {
+        pub fn deleteForward(self: *Self, n: usize) void {
             var it = self.initializeIteratorAtCursor();
             iterateForward(&it, n);
-            try self.buf.replaceRange(self.cursor, it.i - self.cursor, &.{});
+            // we know for a fact that this cant throw because we are shrinking
+            self.buf.replaceRange(self.cursor, it.i - self.cursor, &.{}) catch unreachable;
         }
 
-        pub fn deleteBack(self: *Self, n: usize) !void {
+        pub fn deleteBack(self: *Self, n: usize) void {
             var it = self.initializeIteratorAtCursor();
             iterateBack(&it, n);
-            try self.buf.replaceRange(it.i, self.cursor - it.i, &.{});
+            // we know for a fact that this cant throw because we are shrinking
+            self.buf.replaceRange(it.i, self.cursor - it.i, &.{}) catch unreachable;
             self.cursor = it.i;
         }
 
@@ -287,14 +289,14 @@ test "utf8 input: owned - delete operations" {
 
     try ins(.owned, &utf8_input, "こんにちは");
 
-    try utf8_input.deleteBack(2);
+    utf8_input.deleteBack(2);
     try testing.expectEqualStrings("こんに", utf8_input.buf.items());
     utf8_input.moveCursorBack(2);
-    try utf8_input.deleteForward(1);
+    utf8_input.deleteForward(1);
     try testing.expectEqualStrings("こに", utf8_input.buf.items());
-    try utf8_input.deleteForward(999);
+    utf8_input.deleteForward(999);
     try testing.expectEqualStrings("こ", utf8_input.buf.items());
-    try utf8_input.deleteBack(999);
+    utf8_input.deleteBack(999);
     try testing.expectEqualStrings("", utf8_input.buf.items());
 }
 
@@ -308,7 +310,7 @@ test "utf8 input: borrowed - basic operations" {
     try testing.expectEqualStrings("a", utf8_input.buf.items());
     try utf8_input.insert("b");
     try testing.expectEqualStrings("ab", utf8_input.buf.items());
-    try utf8_input.deleteBack(1);
+    utf8_input.deleteBack(1);
     try testing.expectEqualStrings("a", utf8_input.buf.items());
 }
 


### PR DESCRIPTION
- Add deleteBack and deleteForward functions to Ime type
- Make deleteBack and deleteForward infallible in Utf8Input since they only shrink
- Add tests for deletion operations in both owned and borrowed variants
- Update README with new deletion function examples